### PR TITLE
Revert "run setup on networks in parallel"

### DIFF
--- a/cni.go
+++ b/cni.go
@@ -165,39 +165,16 @@ func (c *libcni) Setup(ctx context.Context, id string, path string, opts ...Name
 	return c.createResult(result)
 }
 
-type asynchAttachResult struct {
-	index int
-	res   *types100.Result
-	err   error
-}
-
-func asynchAttach(ctx context.Context, index int, n *Network, ns *Namespace, wg *sync.WaitGroup, rc chan asynchAttachResult) {
-	defer wg.Done()
-	r, err := n.Attach(ctx, ns)
-	rc <- asynchAttachResult{index: index, res: r, err: err}
-}
-
 func (c *libcni) attachNetworks(ctx context.Context, ns *Namespace) ([]*types100.Result, error) {
-	var wg sync.WaitGroup
-	var firstError error
-	results := make([]*types100.Result, len(c.Networks()))
-	rc := make(chan asynchAttachResult)
-
-	for i, network := range c.Networks() {
-		wg.Add(1)
-		go asynchAttach(ctx, i, network, ns, &wg, rc)
-	}
-
-	for range c.Networks() {
-		rs := <-rc
-		if rs.err != nil && firstError == nil {
-			firstError = rs.err
+	var results []*types100.Result
+	for _, network := range c.Networks() {
+		r, err := network.Attach(ctx, ns)
+		if err != nil {
+			return nil, err
 		}
-		results[rs.index] = rs.res
+		results = append(results, r)
 	}
-	wg.Wait()
-
-	return results, firstError
+	return results, nil
 }
 
 // Remove removes the network config from the namespace


### PR DESCRIPTION
Reverts containerd/go-cni#76 to test if this is the culprit causing worngly assigne netnsids...